### PR TITLE
lib/Makefile: Pass FLAG to make in SUBDIRS target

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -21,7 +21,7 @@ all:  subdirs
 subdirs: $(SUBDIRS)
 
 $(SUBDIRS):
-	$(MAKE) -C $@ $(MAKEARG)
+	$(MAKE) -C $@ FLAG=$(FLAG) $(MAKEARG)
 
 # Rules for making clean:
 clean:

--- a/lib/libnet/Makefile
+++ b/lib/libnet/Makefile
@@ -16,7 +16,7 @@ ifndef TOP
 endif
 include $(TOP)/make.rules
 
-CFLAGS += -I. -I.. -I../libc/include -I$(TOP)/include
+CFLAGS += -I. -I.. -I../libc/include -I$(TOP)/include $(FLAG)
 
 SRCS =	ethernet.c ipv4.c udp.c tcp.c dns.c bootp.c dhcp.c tftp.c \
 	ipv6.c dhcpv6.c icmpv6.c ndp.c netload.c ping.c args.c


### PR DESCRIPTION
Some applications, e.g. https://maas.io/, trust on the dhcp code 93
option to reply the correct pxelinux.0 file according to client
architecture.

Today, dhcp.c is compiled without DHCPARCH, which causes it not to
send client architecture in the dhcp request, i.e. dhcpd server can
reply a pxelinux.0 binary that is not intended for client
architecture.

This patch makes sure client architecture is sent in the dhcp request.

Signed-off-by: Murilo Opsfelder Araujo <muriloo@linux.vnet.ibm.com>